### PR TITLE
Updated READMEs with networking clarification

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
   -   id: check-json
   -   id: check-added-large-files
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.96.3 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
+  rev: v1.97.4 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
   hooks:
   - id: terraform_fmt
     args:

--- a/tools/bastion/README.md
+++ b/tools/bastion/README.md
@@ -8,7 +8,11 @@ To use this module, it is required to have the following:
 - Subscription ID for the `hashicorp/azurerm` provider (required when using v4.x)
   - See the `provider.tf` file for details
 
-> NOTE: All other resources, including the Resource Group, "AzureBastionSubnet" Subnet, Network Security Groups (NSG) with required inbound and outbound rules, Public IP Address, and Bastion Host will be created by this module.
+> [!NOTE]
+> All other resources, including the Resource Group, "**AzureBastionSubnet**" Subnet, Network Security Groups (NSG) with required inbound and outbound rules, Public IP Address, and Bastion Host will be created by this module.
+
+> [!IMPORTANT]
+> The Virtual Network (VNET) should be the **_existing_** VNet within the Subscription that was created as part of your Project Set (ie. `abc123-dev-vwan-spoke`). The subnet will be created within this VNet.
 
 ## Usage
 

--- a/tools/cicd_managed_devops_pools/README.md
+++ b/tools/cicd_managed_devops_pools/README.md
@@ -13,6 +13,9 @@ To use this module, it is required to have the following:
   - Microsoft.DevOpsInfrastructure
   - Microsoft.DevCenter
 
+> [!IMPORTANT]
+> The Virtual Network (VNET) should be the **_existing_** VNet within the Subscription that was created as part of your Project Set (ie. `abc123-dev-vwan-spoke`). The subnet will be created within this VNet.
+
 ## Usage
 
 You must update the values in the `provider.tf` file, specifically the **backend** configuration.

--- a/tools/cicd_self_hosted_agents/README.md
+++ b/tools/cicd_self_hosted_agents/README.md
@@ -12,6 +12,9 @@ To use this module, it is required to have the following:
   - A subnet for the private endpoint
     - There is **no minimum size** required. Keep in mind that this subnet can be used for all Private Endpoints, and is not exclusive to the self-hosted runner solution.
 
+> [!IMPORTANT]
+> The Virtual Network (VNET) should be the **_existing_** VNet within the Subscription that was created as part of your Project Set (ie. `abc123-dev-vwan-spoke`). You should create the required Subnets within this VNet.
+
 ## Usage
 
 You must update the values in the `provider.tf` file, specifically the **backend** configuration.

--- a/tools/cloud_shell_vnet/README.md
+++ b/tools/cloud_shell_vnet/README.md
@@ -8,7 +8,11 @@ To use this module, it is required to have the following:
 - Subscription ID for the `hashicorp/azurerm` provider (required when using v4.x)
   - See the `provider.tf` file for details
 
-> NOTE: All other resources, including 3x Subnets, Network Security Groups (NSGs), Private Endpoints, Relay Namespaces, Storage Accounts, and Storage Shares will be created by this module.
+> [!NOTE]
+> All other resources, including 3x Subnets, Network Security Groups (NSGs), Private Endpoints, Relay Namespaces, Storage Accounts, and Storage Shares will be created by this module.
+
+> [!IMPORTANT]
+> The Virtual Network (VNET) should be the **_existing_** VNet within the Subscription that was created as part of your Project Set (ie. `abc123-dev-vwan-spoke`). The subnets will be created within this VNet.
 
 ## Usage
 


### PR DESCRIPTION
This pull request includes updates to documentation and configuration files across multiple modules. The most significant changes involve adding important notes to README files and updating the version of a pre-commit hook.

Documentation updates:

* [`tools/bastion/README.md`](diffhunk://#diff-7b7cf60e7e75b003cdf6c010092db5444a236b54d169ba0cebb977ab8dd479eaL11-R15): Added an important note about the Virtual Network (VNET) needing to be an existing VNet within the Subscription.
* [`tools/cicd_managed_devops_pools/README.md`](diffhunk://#diff-a8f707c96d96379187e8f8717a4f8352ea7fa0626f1d5677f29282ad052a2fd1R16-R18): Included a similar important note about the VNET being an existing VNet within the Subscription.
* [`tools/cicd_self_hosted_agents/README.md`](diffhunk://#diff-7fe3048b8a3f8e071350a55ae6d0bb694297e0a779262bf3e05c56811c65cf2fR15-R17): Added an important note specifying that the VNET should be an existing VNet within the Subscription.
* [`tools/cloud_shell_vnet/README.md`](diffhunk://#diff-f804cc1d42bf953b7da55ecafe95dc48903504b8f36f1996f5963fc2efb8f407L11-R15): Added an important note about the VNET needing to be an existing VNet within the Subscription.

Configuration updates:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L12-R12): Updated the version of the `pre-commit-terraform` hook from `v1.96.3` to `v1.97.4`.