### PR TITLE
Updated GitHub Self-Hosted Runners README Guidance

### DIFF
--- a/tools/cicd_self_hosted_agents/README.md
+++ b/tools/cicd_self_hosted_agents/README.md
@@ -41,7 +41,7 @@ az provider register --namespace GitHub.Network
 You must update the values in the `provider.tf` file, specifically the **backend** configuration. Please refer to the following Microsoft documentation about [Store Terraform state in Azure Storage](https://learn.microsoft.com/en-us/azure/developer/terraform/store-state-in-azure-storage).
 
 > [!IMPORTANT]
-> The Terraform state Storage Account is not created as part of this module. You must create this outside of this module, and provide the appropriate values in the `provider.tf` file. This Terraform state is **only** used for the self-hosted runners module, and is **not used** with/for any infrastructure that is deployed using the self-hotsed runners.
+> The Terraform state Storage Account is not created as part of this module. You must create this outside of this module, and provide the appropriate values in the `provider.tf` file. This Terraform state is **only** used for the self-hosted runners module, and is **not used** with/for any infrastructure that is deployed using the self-hosted runners.
 
 ```terraform
 backend "azurerm" {

--- a/tools/cicd_self_hosted_agents/README.md
+++ b/tools/cicd_self_hosted_agents/README.md
@@ -14,6 +14,7 @@ To use this module, it is required to have the following:
   - GitHub.Network
 
 **Example Azure CLI:**
+
 ```cli
 az provider register --namespace Microsoft.App
 az provider register --namespace Microsoft.ContainerInstance
@@ -29,13 +30,18 @@ az provider register --namespace GitHub.Network
 > [!NOTE]
 > The `example.auto.tfvars` file will need to provide the appropriate **address_prefixes** for the subnets, based on the size required.
 >
-> The subnet for the container app requires a minimum size of `/27`.
-> The subnet for the container instance requires a minimum size of `/28`.
-> The subnet for the private endpoint has no minimum size requirement, and is not exclusive to the self-hosted runner solution.
+> The subnet for the **container app** requires a minimum size of `/27`.
+>
+> The subnet for the **container instance** requires a minimum size of `/28`.
+>
+> The subnet for the **private endpoint** has no minimum size requirement, and is not exclusive to the self-hosted runner solution.
 
 ## Usage
 
-You must update the values in the `provider.tf` file, specifically the **backend** configuration.
+You must update the values in the `provider.tf` file, specifically the **backend** configuration. Please refer to the following Microsoft documentation about [Store Terraform state in Azure Storage](https://learn.microsoft.com/en-us/azure/developer/terraform/store-state-in-azure-storage).
+
+> [!IMPORTANT]
+> The Terraform state Storage Account is not created as part of this module. You must create this outside of this module, and provide the appropriate values in the `provider.tf` file. This Terraform state is **only** used for the self-hosted runners module, and is **not used** with/for any infrastructure that is deployed using the self-hotsed runners.
 
 ```terraform
 backend "azurerm" {
@@ -49,16 +55,20 @@ backend "azurerm" {
 You must update the values in the `example.auto.tfvars` file.
 
 ```terraform
+subscription_id = "xxx" # This is the subscription ID where the resources will be created (ie. abc123-tools)
+
 resource_group_name = "cicd-self-hosted-agents"
+location            = "Canada Central"
 
 postfix = "cicd"
 
 version_control_system_type         = "github"
 version_control_system_organization = "bcgov-c" # The organization name in the version control system
 version_control_system_repository   = "REPO_NAME"
+# export TF_VAR_github_personal_access_token=<your_github_personal_access_token>
 
-virtual_network_resource_group = "VNET_RESOURCE_GROUP"
-virtual_network_name           = "VNET_NAME"
+virtual_network_resource_group = "VNET_RESOURCE_GROUP" # Existing Virtual Network Resource Group Name (ie. abc123-tools-networking)
+virtual_network_name           = "VNET_NAME" # Existing Virtual Network Name (ie. abc123-tools-vwan-spoke)
 
 container_app_subnet_name           = "SUBNET_NAME"
 container_app_subnet_address_prefix = "1.2.3.4/27" # must be a minimum size of `/27`
@@ -68,6 +78,12 @@ container_instance_subnet_address_prefix = "1.2.3.4/28" # must be a minimum size
 
 private_endpoint_subnet_name           = "SUBNET_NAME"
 private_endpoint_subnet_address_prefix = "1.2.3.4/28"
+
+tags = { # NOTE: Add this to avoid removing tags that have been inherited from the resource group (on subsequent runs)
+  account_coding = "000000000000000000000000"
+  billing_group  = "abc123"
+  ministry_name  = "MINISTRY_NAME"
+}
 ```
 
 ## Post Deployment
@@ -119,7 +135,7 @@ Please refer to the official [terraform-azurerm-avm-ptn-cicd-agents-and-runners]
 | Name | Version |
 |------|---------|
 | <a name="provider_azapi"></a> [azapi](#provider\_azapi) | 2.3.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.24.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.26.0 |
 
 ## Modules
 

--- a/tools/cicd_self_hosted_agents/example.auto.tfvars
+++ b/tools/cicd_self_hosted_agents/example.auto.tfvars
@@ -1,4 +1,4 @@
-subscription_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+subscription_id = "xxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" # This is the subscription ID where the resources will be created (ie. abc123-tools)
 
 resource_group_name = "caf-ghr"
 location            = "Canada Central"
@@ -10,17 +10,17 @@ version_control_system_organization = "bcgov-c"   # The organization name in the
 version_control_system_repository   = "REPO_NAME" # The repository name in the version control system
 # export TF_VAR_github_personal_access_token=<your_github_personal_access_token>
 
-existing_virtual_network_resource_group_name = "abc123-tools-networking"
-existing_virtual_network_name                = "abc123-tools-vwan-spoke"
+existing_virtual_network_resource_group_name = "abc123-tools-networking" # Existing Virtual Network Resource Group Name (ie. abc123-tools-networking)
+existing_virtual_network_name                = "abc123-tools-vwan-spoke" # Existing Virtual Network Name (ie. abc123-tools-vwan-spoke)
 
 container_app_subnet_name           = "ghr-aca"
-container_app_subnet_address_prefix = "1.2.3.4/27" # must be a minimum size of `/27`
+container_app_subnet_address_prefix = "10.41.4.64/27" # must be a minimum size of `/27`
 
 container_instance_subnet_name           = "ghr-aci"
-container_instance_subnet_address_prefix = "1.2.3.4/28" # must be a minimum size of `/28`
+container_instance_subnet_address_prefix = "10.41.4.96/28" # must be a minimum size of `/28`
 
 private_endpoint_subnet_name           = "private-endpoints"
-private_endpoint_subnet_address_prefix = "1.2.3.4/28"
+private_endpoint_subnet_address_prefix = "10.41.4.112/28"
 
 compute_types = ["azure_container_app"]
 

--- a/tools/cicd_self_hosted_agents/example.auto.tfvars
+++ b/tools/cicd_self_hosted_agents/example.auto.tfvars
@@ -1,4 +1,4 @@
-subscription_id = "xxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" # This is the subscription ID where the resources will be created (ie. abc123-tools)
+subscription_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" # This is the subscription ID where the resources will be created (ie. abc123-tools)
 
 resource_group_name = "caf-ghr"
 location            = "Canada Central"


### PR DESCRIPTION
This pull request includes updates and improvements to the `tools/cicd_self_hosted_agents/README.md` and `example.auto.tfvars` files to enhance clarity and provide additional information for users. The most important changes include formatting improvements, additional instructions, and updated example values.

Documentation improvements:

* [`tools/cicd_self_hosted_agents/README.md`](diffhunk://#diff-7fe3048b8a3f8e071350a55ae6d0bb694297e0a779262bf3e05c56811c65cf2fL32-R44): Improved formatting for subnet size requirements and added a note about the Terraform state Storage Account creation. [[1]](diffhunk://#diff-7fe3048b8a3f8e071350a55ae6d0bb694297e0a779262bf3e05c56811c65cf2fL32-R44) [[2]](diffhunk://#diff-7fe3048b8a3f8e071350a55ae6d0bb694297e0a779262bf3e05c56811c65cf2fR58-R71)
* [`tools/cicd_self_hosted_agents/README.md`](diffhunk://#diff-7fe3048b8a3f8e071350a55ae6d0bb694297e0a779262bf3e05c56811c65cf2fR58-R71): Added example values for `subscription_id`, `resource_group_name`, and `location` in the `example.auto.tfvars` file.
* [`tools/cicd_self_hosted_agents/README.md`](diffhunk://#diff-7fe3048b8a3f8e071350a55ae6d0bb694297e0a779262bf3e05c56811c65cf2fL122-R138): Updated provider version for `azurerm` from `4.24.0` to `4.26.0`.

Configuration updates:

* [`tools/cicd_self_hosted_agents/example.auto.tfvars`](diffhunk://#diff-045dde5f8117b554dbc795f5beb3204ae6ba5d78c9f8f597809f58689750d9e6L1-R1): Added comments to clarify the purpose of the `subscription_id` and existing virtual network details. [[1]](diffhunk://#diff-045dde5f8117b554dbc795f5beb3204ae6ba5d78c9f8f597809f58689750d9e6L1-R1) [[2]](diffhunk://#diff-045dde5f8117b554dbc795f5beb3204ae6ba5d78c9f8f597809f58689750d9e6L13-R23)
* [`tools/cicd_self_hosted_agents/example.auto.tfvars`](diffhunk://#diff-045dde5f8117b554dbc795f5beb3204ae6ba5d78c9f8f597809f58689750d9e6L13-R23): Updated example subnet address prefixes for container app, container instance, and private endpoint.