### PR TITLE
Removed prevent_deletion_if_contains_resources AzureRM provider setting

### DIFF
--- a/tools/bastion/provider.tf
+++ b/tools/bastion/provider.tf
@@ -24,12 +24,6 @@ terraform {
 provider "azurerm" {
   use_oidc = true
   features {
-    # NOTE: This is required because we have the Azure Monitor Baseline Alerts policies in place,
-    # which auto-create metric alerts for specific resources types within the Resource Group where the resource is created.
-    # The AMBA metic alerts prevent the deletion of the Resource Group, as they are not created by this module.
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
   }
   # subscription_id is now required with AzureRM provider 4.0. Use either of the following methods:
   # subscription_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"

--- a/tools/cicd_managed_devops_pools/README.md
+++ b/tools/cicd_managed_devops_pools/README.md
@@ -68,9 +68,9 @@ Please refer to the official [terraform-azurerm-avm-res-devopsinfrastructure-poo
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | 2.2.0 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 4.17.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
+| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | ~> 2.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | ~> 4.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6 |
 
 ## Modules
 

--- a/tools/cicd_managed_devops_pools/provider.tf
+++ b/tools/cicd_managed_devops_pools/provider.tf
@@ -34,12 +34,6 @@ terraform {
 provider "azurerm" {
   use_oidc = true
   features {
-    # NOTE: This is required because we have the Azure Monitor Baseline Alerts policies in place,
-    # which auto-create metric alerts for specific resources types within the Resource Group where the resource is created.
-    # The AMBA metic alerts prevent the deletion of the Resource Group, as they are not created by this module.
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
   }
   # subscription_id is now required with AzureRM provider 4.0. Use either of the following methods:
   # subscription_id = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"

--- a/tools/cicd_self_hosted_agents/README.md
+++ b/tools/cicd_self_hosted_agents/README.md
@@ -110,10 +110,6 @@ When deploying the self-hosted runners, the DNS configuration is added to the Az
 
 It has been observed that despite the DNS configuration being removed on subsequent `terraform apply` runs, the DNS configuration is automatically re-added by the Azure Policy in the Landing Zones.
 
-### Deleting Deployment
-
-When deleting this deployment, if using the `azure_container_app` **Compute Type**, the Resource Group that is automatically created by the Azure Container App Service (ie. `RESOURCE_GROUP_NAME_container_app_infra`) is not deleted, even though `prevent_deletion_if_contains_resources = false` is set in the `provider.tf` file. You will need to manually delete this Resource Group.
-
 ### Other
 
 Please refer to the official [terraform-azurerm-avm-ptn-cicd-agents-and-runners](https://github.com/Azure/terraform-azurerm-avm-ptn-cicd-agents-and-runners) GitHub repository for any known issues.

--- a/tools/cicd_self_hosted_agents/provider.tf
+++ b/tools/cicd_self_hosted_agents/provider.tf
@@ -39,12 +39,6 @@ terraform {
 provider "azurerm" {
   use_oidc = true
   features {
-    # NOTE: This is required because we have the Azure Monitor Baseline Alerts policies in place,
-    # which auto-create metric alerts for specific resources types within the Resource Group where the resource is created.
-    # The AMBA metic alerts prevent the deletion of the Resource Group, as they are not created by this module.
-    resource_group {
-      prevent_deletion_if_contains_resources = false
-    }
   }
 
   # subscription_id is now required with AzureRM provider 4.0. Use either of the following methods:


### PR DESCRIPTION
This pull request primarily removes custom configuration for resource group deletion in the `azurerm` provider across several Terraform modules, and updates provider version specifications for consistency. The goal is to simplify provider configuration and documentation, reflecting a shift away from managing resource group deletion behavior via the `prevent_deletion_if_contains_resources` setting.

Provider configuration cleanup:

* Removed the `resource_group.prevent_deletion_if_contains_resources = false` block and associated comments from the `azurerm` provider configuration in `tools/bastion/provider.tf`, `tools/cicd_managed_devops_pools/provider.tf`, and `tools/cicd_self_hosted_agents/provider.tf`. This eliminates custom handling for resource group deletion and relies on default provider behavior. [[1]](diffhunk://#diff-370e848b1ea10733b953ec14575d9dfb0670fa7738ec3f2bfaf5c4c1a0290cdcL27-L32) [[2]](diffhunk://#diff-09cbb3a34c04dfe591e42bd59a2a6954f191068bd1f897a17f666cdac3100e32L37-L42) [[3]](diffhunk://#diff-6098bca13bda29a746cba25452a37b359f10d3ce1b9f8457a0befbe4f0f37a77L42-L47)

Documentation updates:

* Updated provider version constraints in `tools/cicd_managed_devops_pools/README.md` to use a more flexible version syntax (`~>`) for `azapi`, `azurerm`, and `random` providers.
* Removed documentation about manual resource group deletion from `tools/cicd_self_hosted_agents/README.md` since the provider configuration related to this behavior has been removed.